### PR TITLE
1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 ## Release History
 
+* 1.0.0 Adding typescript.
+
 * 0.2.4 Use jest for testing and remove unused dependencies

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ $ npm install promise-iterate
 Changelog
 ---------
 
+* 1.0.0 Adding typescript.
+
 * 0.2.3 Fix loading on Node >= 7.6.0.
 
 * 0.2.2 Fix package.json again so it can be published properly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promise-iterate",
-  "version": "0.2.4",
+  "version": "1.0.0",
   "description": "Iteration over cursor-like objects with async/await",
   "scripts": {
     "build": "rm -rf dist/ && tsc",


### PR DESCRIPTION
* there's no CD pipeline in this public repo, so we have to manually bump, tag and [release](https://docs.npmjs.com/cli/v10/commands/npm-publish) versions (eg 539eaae)
* `npm pack --dry-run` seems reasonable
* <img src="https://github.com/user-attachments/assets/bcf817bb-f118-48f1-ab48-3f42940f17e2" width="350"/>
